### PR TITLE
Allow to reset mainnet DSChain

### DIFF
--- a/DashSync/Models/DSChain.h
+++ b/DashSync/Models/DSChain.h
@@ -162,6 +162,8 @@ FOUNDATION_EXPORT NSString* const DSChainBlocksDidChangeNotification;
 +(DSChain*)mainnet;
 +(DSChain*)testnet;
 
++ (void)resetMainnet;
+
 +(DSChain* _Nullable)devnetWithIdentifier:(NSString*)identifier;
 +(DSChain*)setUpDevnetWithIdentifier:(NSString*)identifier withCheckpoints:(NSArray<DSCheckpoint*>* _Nullable)checkpointArray withDefaultPort:(uint32_t)port withDefaultDapiPort:(uint32_t)dapiPort;
 

--- a/DashSync/Models/DSChain.m
+++ b/DashSync/Models/DSChain.m
@@ -293,17 +293,18 @@ static checkpoint mainnet_checkpoint_array[] = {
     return chainEntity;
 }
 
+static DSChain* _mainnet = nil;
+static dispatch_once_t mainnetToken = 0;
+static BOOL mainnetInSetUp = FALSE;
+
 +(DSChain*)mainnet {
-    static DSChain* _mainnet = nil;
-    static dispatch_once_t mainnetToken = 0;
-    __block BOOL inSetUp = FALSE;
     dispatch_once(&mainnetToken, ^{
         _mainnet = [[DSChain alloc] initWithType:DSChainType_MainNet checkpoints:[DSChain createCheckpointsArrayFromCheckpoints:mainnet_checkpoint_array count:(sizeof(mainnet_checkpoint_array)/sizeof(*mainnet_checkpoint_array))] port:MAINNET_STANDARD_PORT dapiPort:MAINNET_DAPI_STANDARD_PORT];
         
-        inSetUp = TRUE;
+        mainnetInSetUp = TRUE;
         //NSLog(@"%@",[NSData dataWithUInt256:_mainnet.checkpoints[0].checkpointHash]);
     });
-    if (inSetUp) {
+    if (mainnetInSetUp) {
         [[DSChainEntity context] performBlockAndWait:^{
             DSChainEntity * chainEntity = [_mainnet chainEntity];
             _mainnet.totalMasternodeCount = chainEntity.totalMasternodeCount;
@@ -331,6 +332,12 @@ static checkpoint mainnet_checkpoint_array[] = {
     }
     
     return _testnet;
+}
+
++ (void)resetMainnet {
+    _mainnet = nil;
+    mainnetToken = 0;
+    mainnetInSetUp = FALSE;
 }
 
 static NSMutableDictionary * _devnetDictionary = nil;


### PR DESCRIPTION
We need to re-initialized DSChain instance after migration of data models in the DashWallet