### PR TITLE
Fixed a rare EXC_BAD_ACCESS crash in DSOperationQueue

### DIFF
--- a/DashSync/Libraries/AdvancedOperations/Operation Queue/DSOperationQueue.m
+++ b/DashSync/Libraries/AdvancedOperations/Operation Queue/DSOperationQueue.m
@@ -64,10 +64,15 @@
                 [weakSelf addOperation:producedOperation];
             }
             finishHandler:^(DSOperation *operation, NSArray *errors) {
-                [weakSelf.chainOperationsCache removeObject:operation];
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                if (!strongSelf) {
+                    return;
+                }
 
-                if ([weakSelf.delegate respondsToSelector:@selector(operationQueue:operationDidFinish:withErrors:)]) {
-                    [weakSelf.delegate operationQueue:weakSelf operationDidFinish:operation withErrors:errors];
+                [strongSelf.chainOperationsCache removeObject:operation];
+
+                if ([strongSelf.delegate respondsToSelector:@selector(operationQueue:operationDidFinish:withErrors:)]) {
+                    [strongSelf.delegate operationQueue:strongSelf operationDidFinish:operation withErrors:errors];
                 }
             }];
 

--- a/DashSync/Libraries/AdvancedOperations/Operations/NSOperation+DSOperationKit.m
+++ b/DashSync/Libraries/AdvancedOperations/Operations/NSOperation+DSOperationKit.m
@@ -65,13 +65,23 @@
          chaining them together.
          */
         self.completionBlock = ^{
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+
             existing();
-            block(weakSelf);
+            block(strongSelf);
         };
     }
     else {
         self.completionBlock = ^() {
-            block(weakSelf);
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+
+            block(strongSelf);
         };
     }
 }


### PR DESCRIPTION
Fixed a rare EXC_BAD_ACCESS crash while removing the operation from `chainOperationsCache` when it was canceled (self was deallocated);
Fixed few places in the code where __weak reference used repeatedly which is potentially unsafe