### PR TITLE
Remove built-in chaining support from DSOperation

### DIFF
--- a/DashSync/Libraries/AdvancedOperations/Operations/DSOperation.h
+++ b/DashSync/Libraries/AdvancedOperations/Operations/DSOperation.h
@@ -18,7 +18,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import "DSChainableOperationProtocol.h"
 #import "DSOperationConditionProtocol.h"
 #import "DSOperationObserverProtocol.h"
 
@@ -49,7 +48,7 @@ typedef NS_ENUM(NSUInteger, DSOperationState) {
 
 @class DSOperationQueue;
 
-@interface DSOperation : NSOperation <DSChainableOperationProtocol>
+@interface DSOperation : NSOperation
 
 @property (readonly, getter=isCancelled) BOOL cancelled;
 @property (nonatomic, assign) BOOL userInitiated;
@@ -60,8 +59,6 @@ typedef NS_ENUM(NSUInteger, DSOperationState) {
 @property (nonatomic, copy, readonly) NSArray<NSObject<DSOperationConditionProtocol> *> *conditions;
 @property (nonatomic, copy, readonly) NSArray<NSObject<DSOperationObserverProtocol> *> *observers;
 @property (nonatomic, copy, readonly) NSArray<NSError *> *internalErrors;
-
-@property (nonatomic, strong, readonly) NSHashTable<DSOperation<DSChainableOperationProtocol> *> *chainedOperations;
 
 - (void)addObserver:(NSObject<DSOperationObserverProtocol> *)observer;
 - (void)addCondition:(NSObject<DSOperationConditionProtocol> *)condition;
@@ -80,9 +77,6 @@ typedef NS_ENUM(NSUInteger, DSOperationState) {
 
 - (void)execute;
 - (void)produceOperation:(NSOperation *)operation NS_REQUIRES_SUPER;
-
-- (DSOperation<DSChainableOperationProtocol> *)chainWithOperation:(DSOperation<DSChainableOperationProtocol> *)operation;
-+ (void)chainOperations:(NSArray<DSOperation<DSChainableOperationProtocol> *> *)operations;
 
 @end
 

--- a/DashSync/Models/Managers/Service Managers/Price/DSHTTPGETOperation.h
+++ b/DashSync/Models/Managers/Service Managers/Price/DSHTTPGETOperation.h
@@ -16,6 +16,7 @@
 //
 
 #import "DSOperation.h"
+#import "DSChainableOperationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -26,7 +27,7 @@ extern NSString *const DSHTTPGETOperationErrorDomain;
  Chainable operation, always first in the chain
  Has side-effect of updating secure time in `DSAuthenticationManager`
  */
-@interface DSHTTPGETOperation : DSOperation
+@interface DSHTTPGETOperation : DSOperation <DSChainableOperationProtocol>
 
 - (instancetype)initWithRequest:(NSURLRequest *)request;
 

--- a/DashSync/Models/Managers/Service Managers/Price/ParseOperations/DSParseResponseOperation.h
+++ b/DashSync/Models/Managers/Service Managers/Price/ParseOperations/DSParseResponseOperation.h
@@ -16,6 +16,7 @@
 //
 
 #import "DSOperation.h"
+#import "DSChainableOperationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,7 +29,7 @@ typedef NS_ENUM(NSUInteger, DSParseResponseOperationErrorCode) {
 /**
  Abstract chainable operation, follows `DSHTTPGETOperation`
  */
-@interface DSParseResponseOperation : DSOperation
+@interface DSParseResponseOperation : DSOperation <DSChainableOperationProtocol>
 
 @property (readonly, strong, nonatomic, nullable) id responseToParse;
 


### PR DESCRIPTION
Fixes EXC_BAD_ACCESS crash in finishHandler of operation observer