### PR TITLE
Fixes crash when Spark API returns invalid response

### DIFF
--- a/DashSync/Models/Managers/Service Managers/Price/ParseOperations/DSParseSparkResponseOperation.m
+++ b/DashSync/Models/Managers/Service Managers/Price/ParseOperations/DSParseSparkResponseOperation.m
@@ -39,9 +39,17 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    if (![response.allKeys.firstObject isKindOfClass:NSString.class] ||
-        ![response.allValues.firstObject isKindOfClass:NSNumber.class]) {
-
+    BOOL responseIsValid = YES;
+    for (id key in response) {
+        id value = response[key];
+        
+        responseIsValid = [key isKindOfClass:NSString.class] && [value isKindOfClass:NSNumber.class];
+        if (!responseIsValid) {
+            break;
+        }
+    }
+    
+    if (!responseIsValid) {
         [self cancelWithError:[self.class invalidResponseErrorWithUserInfo:@{NSDebugDescriptionErrorKey : response}]];
 
         return;


### PR DESCRIPTION
Spark API may return a response with `null` values when it failed to fetch prices from its source APIs. For instance:

``` json
{
  "AED": null,
  "AFN": null,
  "ALL": null,
  "AMD": null,
  "ANG": null,
```