### PR TITLE
Use an updated version of TinyCborObjc

### DIFF
--- a/DashSync.podspec
+++ b/DashSync.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.dependency 'DWAlertController', '0.2.1'
   s.dependency 'DSDynamicOptions', '0.1.1'
   s.dependency 'DAPI-GRPC', '0.0.1'
-  s.dependency 'TinyCborObjc', '0.4.2'
+  s.dependency 'TinyCborObjc', '0.4.3'
   s.prefix_header_contents = '#import "DSEnvironment.h"'
   
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -32,7 +32,7 @@ PODS:
     - DSDynamicOptions (= 0.1.1)
     - DWAlertController (= 0.2.1)
     - secp256k1_dash (= 0.1.3-alpha.2)
-    - TinyCborObjc (= 0.4.2)
+    - TinyCborObjc (= 0.4.3)
   - DSDynamicOptions (0.1.1)
   - DWAlertController (0.2.1)
   - gRPC-Core (1.26.0):
@@ -78,9 +78,9 @@ PODS:
     - SDWebImage/Core (= 5.0.1)
   - SDWebImage/Core (5.0.1)
   - secp256k1_dash (0.1.3-alpha.2)
-  - tinycbor (0.5.3-alpha3)
-  - TinyCborObjc (0.4.2):
-    - tinycbor (= 0.5.3-alpha3)
+  - tinycbor (0.5.3)
+  - TinyCborObjc (0.4.3):
+    - tinycbor (= 0.5.3)
 
 DEPENDENCIES:
   - DAPI-GRPC (from `../`)
@@ -121,7 +121,7 @@ SPEC CHECKSUMS:
   BoringSSL-GRPC: 8f2c6b5fbae71d1f3aabb787a52fd4929d1eef33
   CocoaLumberjack: 78b0c238666f4f58db069738ec176f4519557516
   DAPI-GRPC: faca236b4d2357cbab85a67a8341e4eeb6c51798
-  DashSync: 3ac9d1daacd721d8aeae2ab2430b303b1743bbf4
+  DashSync: 3b27159c06e34893f0f5ba547b04522aef3ec35c
   DSDynamicOptions: 23229bb4e60e7fc966cc1842eb405ea3b94b042e
   DWAlertController: 5f4cd8adf90336331c054857f709f5f8d4b16a5b
   gRPC: 01cad0fe812eb92170a8748b7507607752350e2b
@@ -132,8 +132,8 @@ SPEC CHECKSUMS:
   Protobuf: dd1aaea7140debfe4dd0683fb8ef208e527ae153
   SDWebImage: 27dd2c9ea07a2252f94557c9fbb6105ee94b74c9
   secp256k1_dash: 5a10f3369ea82b75bb655c2f3fa119debbaa10ee
-  tinycbor: f3596b9acc8493b19c9e0cc2d0417d9c7aa58daa
-  TinyCborObjc: 9a095ec8486e609f52e1254d97735d65fe77371c
+  tinycbor: 1a978845921ea4befaf5c977e55b3f0e09a80395
+  TinyCborObjc: 467e99890f005b85af9dad281129edd43f33cd0a
 
 PODFILE CHECKSUM: 3172746975d8992a323f5d3ed6240dbd8397eba6
 


### PR DESCRIPTION
Includes https://github.com/dashevo/TinyCborObjc/pull/12 and uses the latest release version of tinycbor dependency.