### PR TITLE
weighted progress and special transaction block heights fix when not in an account

### DIFF
--- a/DashSync/DashSync.m
+++ b/DashSync/DashSync.m
@@ -169,6 +169,7 @@ static NSString * const BG_TASK_REFRESH_IDENTIFIER = @"org.dashcore.dashsync.bac
         [DSDashpayUserEntity deleteContactsOnChainEntity:chainEntity];// this must move after wipeBlockchainInfo where blockchain identities are removed
         [context ds_save];
         [chain reloadDerivationPaths];
+        [chain.chainManager assingSyncWeights];
         
         dispatch_async(dispatch_get_main_queue(), ^{
             [[NSNotificationCenter defaultCenter] postNotificationName:DSWalletBalanceDidChangeNotification object:nil];
@@ -198,6 +199,7 @@ static NSString * const BG_TASK_REFRESH_IDENTIFIER = @"org.dashcore.dashsync.bac
         [DSDashpayUserEntity deleteContactsOnChainEntity:chainEntity];// this must move after wipeBlockchainInfo where blockchain identities are removed
         [context ds_save];
         [chain reloadDerivationPaths];
+        [chain.chainManager assingSyncWeights];
         
         dispatch_async(dispatch_get_main_queue(), ^{
             [[NSNotificationCenter defaultCenter] postNotificationName:DSWalletBalanceDidChangeNotification object:nil];
@@ -220,6 +222,7 @@ static NSString * const BG_TASK_REFRESH_IDENTIFIER = @"org.dashcore.dashsync.bac
         DSChainManager * chainManager = [[DSChainsManager sharedInstance] chainManagerForChain:chain];
         [chainManager.masternodeManager wipeMasternodeInfo];
         [context ds_save];
+        [chain.chainManager assingSyncWeights];
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:[NSString stringWithFormat:@"%@_%@",chain.uniqueID,LAST_SYNCED_MASTERNODE_LIST]];
         dispatch_async(dispatch_get_main_queue(), ^{
             [[NSNotificationCenter defaultCenter] postNotificationName:DSMasternodeListDidChangeNotification object:nil userInfo:@{DSChainManagerNotificationChainKey:chain}];

--- a/DashSync/Models/Managers/Chain Managers/DSChainManager+Protected.h
+++ b/DashSync/Models/Managers/Chain Managers/DSChainManager+Protected.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) DSChainSyncPhase syncPhase;
 
+-(void)assingSyncWeights;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/DashSync/Models/Managers/Chain Managers/DSChainManager.h
+++ b/DashSync/Models/Managers/Chain Managers/DSChainManager.h
@@ -55,6 +55,9 @@ typedef void (^MultipleBlockMiningCompletionBlock)(NSArray<DSFullBlock *>* block
 @property (nonatomic, readonly) double chainSyncProgress;
 @property (nonatomic, readonly) double terminalHeaderSyncProgress;
 @property (nonatomic, readonly) double combinedSyncProgress;
+@property (nonatomic, readonly) double chainSyncWeight;
+@property (nonatomic, readonly) double terminalHeaderSyncWeight;
+@property (nonatomic, readonly) double masternodeListSyncWeight;
 @property (nonatomic, readonly) DSSporkManager * sporkManager;
 @property (nonatomic, readonly) DSMasternodeManager * masternodeManager;
 @property (nonatomic, readonly) DSGovernanceSyncManager * governanceSyncManager;

--- a/DashSync/Models/Managers/Chain Managers/DSMasternodeManager.h
+++ b/DashSync/Models/Managers/Chain Managers/DSMasternodeManager.h
@@ -48,6 +48,7 @@ FOUNDATION_EXPORT NSString* const DSQuorumListDidChangeNotification;
 @property (nonatomic,readonly) NSUInteger knownMasternodeListsCount;
 @property (nonatomic,readonly) uint32_t earliestMasternodeListBlockHeight;
 @property (nonatomic,readonly) uint32_t lastMasternodeListBlockHeight;
+@property (nonatomic,readonly) uint32_t estimatedMasternodeListsToSync;
 @property (nonatomic,readonly) DSMasternodeList * currentMasternodeList;
 @property (nonatomic,readonly) double masternodeListAndQuorumsSyncProgress;
 @property (nonatomic,readonly) NSUInteger masternodeListRetrievalQueueCount;

--- a/DashSync/Models/Managers/Chain Managers/DSMasternodeManager.m
+++ b/DashSync/Models/Managers/Chain Managers/DSMasternodeManager.m
@@ -193,6 +193,26 @@
     return self.masternodeListRetrievalQueue.count;
 }
 
+-(uint32_t)estimatedMasternodeListsToSync {
+    BOOL syncMasternodeLists = ([[DSOptionsManager sharedInstance] syncType] & DSSyncType_MasternodeList);
+    if (!syncMasternodeLists) {
+        return 0;
+    }
+    double amountLeft = self.masternodeListRetrievalQueue.count;
+    double maxAmount = self.masternodeListRetrievalQueueMaxAmount;
+    double masternodeListsCount = self.masternodeListsByBlockHash.count;
+    if (!maxAmount || masternodeListsCount <= 1) { //1 because there might be a default
+        if (self.lastMasternodeListBlockHeight == UINT32_MAX) {
+            return 32;
+        } else {
+            float diff = self.chain.estimatedBlockHeight - self.lastMasternodeListBlockHeight;
+            if (diff < 0) return 32;
+            return MIN(32,(uint32_t)ceil(diff / 24.0f));
+        }
+    }
+    return amountLeft;
+}
+
 -(double)masternodeListAndQuorumsSyncProgress
 {
     double amountLeft = self.masternodeListRetrievalQueue.count;

--- a/DashSync/Models/Wallet/DSSpecialTransactionsWalletHolder.h
+++ b/DashSync/Models/Wallet/DSSpecialTransactionsWalletHolder.h
@@ -43,6 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
 // this is used to save transactions atomically with the block
 - (void)persistIncomingTransactionsAttributesForBlockSaveWithNumber:(uint32_t)blockNumber inContext:(NSManagedObjectContext*)context;
 
+- (NSArray *)setBlockHeight:(int32_t)height andTimestamp:(NSTimeInterval)timestamp forTransactionHashes:(NSArray *)txHashes;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/DashSync/Models/Wallet/DSSpecialTransactionsWalletHolder.m
+++ b/DashSync/Models/Wallet/DSSpecialTransactionsWalletHolder.m
@@ -354,4 +354,23 @@
 //    return lastSubscriptionTransactionHash;
 //}
 
+// set the block heights and timestamps for the given transactions, use a height of TX_UNCONFIRMED and timestamp of 0 to
+// indicate a transaction and it's dependents should remain marked as unverified (not 0-conf safe)
+- (NSArray *)setBlockHeight:(int32_t)height andTimestamp:(NSTimeInterval)timestamp forTransactionHashes:(NSArray *)txHashes
+{
+    NSMutableArray *updated = [NSMutableArray array];
+    for (NSValue *hash in txHashes) {
+        DSTransaction *tx = [self transactionForHash:uint256_data_from_obj(hash).UInt256];
+        
+        if (! tx || (tx.blockHeight == height && tx.timestamp == timestamp)) continue;
+        DSDLog(@"Setting tx %@ height to %d",tx,height);
+        tx.blockHeight = height;
+        tx.timestamp = timestamp;
+        
+        [updated addObject:tx];
+    }
+    
+    return updated;
+}
+
 @end

--- a/DashSync/Models/Wallet/DSWallet.m
+++ b/DashSync/Models/Wallet/DSWallet.m
@@ -911,6 +911,7 @@
             [self chainUpdatedBlockHeight:height];
         }
     }
+    [self.specialTransactionsHolder setBlockHeight:height andTimestamp:timestamp forTransactionHashes:txHashes];
     return [updated copy];
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
The progress bar didn't work all that well, it used to be a specific amount per sync phase, now it will guess the weight of each sync phase and seem more fluid to the end user.

Special transactions that were not part of an account were not having their block height set.


## What was done?
We use weights for different sync phases.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone