### PR TITLE
Leak-free destructible merk lib & c header

### DIFF
--- a/DashSync/lib/libmerkiOS.a
+++ b/DashSync/lib/libmerkiOS.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ad486c63a353a9c0274416102736387900ea3a2144d703b4c324df25e53766e
-size 40116072
+oid sha256:cf584e69a2a34ef2110a9d98fc47792f3a267803dadb8ab9eea44e6d68ade8cc
+size 39354456

--- a/DashSync/shared/Categories/NSData/NSData+DSMerkAVLTree.m
+++ b/DashSync/shared/Categories/NSData/NSData+DSMerkAVLTree.m
@@ -21,7 +21,7 @@
 @implementation NSData (DSMerkAVLTree)
 
 - (NSData *)executeProofReturnElementDictionary:(NSDictionary **)rElementDictionary {
-    const ExecuteProofResult *result = execute_proof_c(self.bytes, self.length);
+    ExecuteProofResult *result = execute_proof_c(self.bytes, self.length);
     if (result == nil) {
         return nil;
     }
@@ -32,6 +32,7 @@
         [mElementDictionary setObject:[NSData dataWithBytes:element->value length:element->value_length] forKey:[NSData dataWithBytes:element->key length:element->key_length]];
     }
     *rElementDictionary = [mElementDictionary copy];
+    destroy_proof_c(result);
     return rootHash;
 }
 

--- a/DashSync/shared/crypto/merk.h
+++ b/DashSync/shared/crypto/merk.h
@@ -17,4 +17,6 @@ typedef struct ExecuteProofResult {
   struct Element **elements;
 } ExecuteProofResult;
 
-const struct ExecuteProofResult *execute_proof_c(const uint8_t *c_array, uintptr_t length);
+struct ExecuteProofResult *execute_proof_c(const uint8_t *c_array, uintptr_t length);
+
+void destroy_proof_c(struct ExecuteProofResult *proof_result);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
New libs built with updated [c-rust wrapper](https://github.com/dashevo/rs-merk-verify-c-binding)
## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now the memory is freed correctly. So memory leaks in wrapper were excluded.

## What was done?
<!--- Describe your changes in detail -->
Now the destructor created for the correct memory release of objects created in rust is called.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was tested using Xcode Instruments pointed out that there is no memory leaks anymore

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone