### PR TITLE
Added method to sign and verify signature digests

### DIFF
--- a/DashSync/shared/Models/Identity/DSBlockchainIdentity+Protected.h
+++ b/DashSync/shared/Models/Identity/DSBlockchainIdentity+Protected.h
@@ -63,6 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addKey:(DSKey *)key atIndexPath:(NSIndexPath *)indexPath ofType:(DSKeyType)type withStatus:(DSBlockchainIdentityKeyStatus)status save:(BOOL)save;
 - (BOOL)registerKeyWithStatus:(DSBlockchainIdentityKeyStatus)status atIndexPath:(NSIndexPath *)indexPath ofType:(DSKeyType)type;
 - (DSKey *_Nullable)privateKeyAtIndex:(uint32_t)index ofType:(DSKeyType)type;
+- (DSKey *_Nullable)privateKeyAtIndex:(uint32_t)index ofType:(DSKeyType)type forSeed:(NSData *)seed;
 - (void)deletePersistentObjectAndSave:(BOOL)save inContext:(NSManagedObjectContext *)context;
 
 - (void)saveInitial;

--- a/DashSync/shared/Models/Identity/DSBlockchainIdentity.h
+++ b/DashSync/shared/Models/Identity/DSBlockchainIdentity.h
@@ -244,6 +244,8 @@ FOUNDATION_EXPORT NSString *const DSBlockchainIdentityUpdateEventDashpaySyncroni
 
 - (void)signStateTransition:(DSTransition *)transition forKeyIndex:(uint32_t)keyIndex ofType:(DSKeyType)signingAlgorithm completion:(void (^_Nullable)(BOOL success))completion;
 
+- (void)signMessageDigest:(UInt256)digest forKeyIndex:(uint32_t)keyIndex ofType:(DSKeyType)signingAlgorithm completion:(void (^_Nullable)(BOOL success, NSData *signature))completion;
+
 - (BOOL)verifySignature:(NSData *)signature forKeyIndex:(uint32_t)keyIndex ofType:(DSKeyType)signingAlgorithm forMessageDigest:(UInt256)messageDigest;
 
 - (BOOL)verifySignature:(NSData *)signature ofType:(DSKeyType)signingAlgorithm forMessageDigest:(UInt256)messageDigest;

--- a/DashSync/shared/Models/Identity/DSBlockchainIdentity.h
+++ b/DashSync/shared/Models/Identity/DSBlockchainIdentity.h
@@ -323,6 +323,12 @@ FOUNDATION_EXPORT NSString *const DSBlockchainIdentityUpdateEventDashpaySyncroni
 /*! @brief This is a helper to easily get the public message of the matching dashpay user. */
 @property (nonatomic, readonly, nullable) NSString *publicMessage;
 
+/*! @brief This is a helper to easily get the last time the profile was updated of the matching dashpay user. */
+@property (nonatomic, assign) uint64_t dashpayProfileUpdatedAt;
+
+/*! @brief This is a helper to easily get the creation time of the profile of the matching dashpay user. */
+@property (nonatomic, assign) uint64_t dashpayProfileCreatedAt;
+
 - (void)sendNewFriendRequestToBlockchainIdentity:(DSBlockchainIdentity *)blockchainIdentity completion:(void (^)(BOOL success, NSArray<NSError *> *_Nullable errors))completion;
 
 - (void)sendNewFriendRequestToPotentialContact:(DSPotentialContact *)potentialContact completion:(void (^_Nullable)(BOOL success, NSArray<NSError *> *errors))completion;

--- a/DashSync/shared/Models/Identity/DSBlockchainIdentity.m
+++ b/DashSync/shared/Models/Identity/DSBlockchainIdentity.m
@@ -912,6 +912,24 @@ typedef NS_ENUM(NSUInteger, DSBlockchainIdentityKeyDictionary)
     }
 }
 
+- (uint64_t)dashpayProfileUpdatedAt {
+    if (self.transientDashpayUser) {
+        return self.transientDashpayUser.updatedAt;
+    }
+    else {
+        return self.matchingDashpayUserInViewContext.updatedAt;
+    }
+}
+
+- (uint64_t)dashpayProfileCreatedAt {
+    if (self.transientDashpayUser) {
+        return self.transientDashpayUser.createdAt;
+    }
+    else {
+        return self.matchingDashpayUserInViewContext.createdAt;
+    }
+}
+
 // MARK: - Keys
 
 - (void)createFundingPrivateKeyWithSeed:(NSData *)seed isForInvitation:(BOOL)isForInvitation completion:(void (^_Nullable)(BOOL success))completion {

--- a/DashSync/shared/Models/Identity/DSBlockchainIdentity.m
+++ b/DashSync/shared/Models/Identity/DSBlockchainIdentity.m
@@ -63,7 +63,7 @@
 #import <TinyCborObjc/NSObject+DSCborEncoding.h>
 
 #define BLOCKCHAIN_USER_UNIQUE_IDENTIFIER_KEY @"BLOCKCHAIN_USER_UNIQUE_IDENTIFIER_KEY"
-#define DEFAULT_SIGNING_ALGORITH DSKeyType_ECDSA
+#define DEFAULT_SIGNING_ALGORITHM DSKeyType_ECDSA
 #define DEFAULT_FETCH_IDENTITY_RETRY_COUNT 5
 #define DEFAULT_FETCH_USERNAMES_RETRY_COUNT 5
 #define DEFAULT_FETCH_PROFILE_RETRY_COUNT 5
@@ -1851,9 +1851,21 @@ typedef NS_ENUM(NSUInteger, DSBlockchainIdentityKeyDictionary)
 - (void)signStateTransition:(DSTransition *)transition completion:(void (^_Nullable)(BOOL success))completion {
     if (!self.keysCreated) {
         uint32_t index;
-        [self createNewKeyOfType:DEFAULT_SIGNING_ALGORITH saveKey:!self.wallet.isTransient returnIndex:&index];
+        [self createNewKeyOfType:DEFAULT_SIGNING_ALGORITHM saveKey:!self.wallet.isTransient returnIndex:&index];
     }
     return [self signStateTransition:transition forKeyIndex:self.currentMainKeyIndex ofType:self.currentMainKeyType completion:completion];
+}
+
+- (void)signMessageDigest:(UInt256)digest forKeyIndex:(uint32_t)keyIndex ofType:(DSKeyType)signingAlgorithm completion:(void (^_Nullable)(BOOL success, NSData *signature))completion {
+    NSParameterAssert(completion);
+    DSKey *privateKey = [self privateKeyAtIndex:keyIndex ofType:signingAlgorithm];
+    NSAssert(privateKey, @"The private key should exist");
+    NSAssert([privateKey.publicKeyData isEqualToData:[self publicKeyAtIndex:keyIndex ofType:signingAlgorithm].publicKeyData], @"These should be equal");
+    NSParameterAssert(privateKey);
+
+    DSLogPrivate(@"Private Key is %@", [privateKey serializedPrivateKeyForChain:self.chain]);
+    DSLogPrivate(@"Signing %@ with key %@", uint256_hex(digest), privateKey.publicKeyData.hexString);
+    [privateKey signMessageDigest:digest completion:completion];
 }
 
 - (BOOL)verifySignature:(NSData *)signature ofType:(DSKeyType)signingAlgorithm forMessageDigest:(UInt256)messageDigest {

--- a/DashSync/shared/Models/Keys/DSBLSKey.mm
+++ b/DashSync/shared/Models/Keys/DSBLSKey.mm
@@ -369,6 +369,17 @@
     return signature;
 }
 
+- (void)signMessageDigest:(UInt256)digest completion:(void (^_Nullable)(BOOL success, NSData *signature))completion {
+    NSParameterAssert(completion);
+    NSData *signatureData = nil;
+    UInt768 signature = [self signDigest:digest];
+    BOOL success = uint768_is_not_zero(signature);
+    if (success) {
+        signatureData = uint768_data(signature);
+    }
+    completion(success, signatureData);
+}
+
 // MARK: - HMAC
 
 - (UInt256)HMAC256Data:(NSData *)data {

--- a/DashSync/shared/Models/Keys/DSECDSAKey.m
+++ b/DashSync/shared/Models/Keys/DSECDSAKey.m
@@ -660,6 +660,13 @@ int DSSecp256k1PointMul(DSECPoint *p, const UInt256 *i) {
     return sig;
 }
 
+- (void)signMessageDigest:(UInt256)digest completion:(void (^_Nullable)(BOOL success, NSData *signature))completion {
+    NSParameterAssert(completion);
+    NSData *signatureData = [((DSECDSAKey *)self) compactSign:digest];
+    BOOL success = (signatureData != nil);
+    completion(success, signatureData);
+}
+
 - (DSKeyType)keyType {
     return DSKeyType_ECDSA;
 }

--- a/DashSync/shared/Models/Keys/DSKey.h
+++ b/DashSync/shared/Models/Keys/DSKey.h
@@ -53,6 +53,9 @@ typedef NS_ENUM(NSUInteger, DSKeyType)
 
 - (UInt256)HMAC256Data:(NSData *)data;
 
+- (void)signMessageDigest:(UInt256)digest completion:(void (^_Nullable)(BOOL success, NSData *signature))completion;
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/DashSync/shared/Models/Keys/DSKey.m
+++ b/DashSync/shared/Models/Keys/DSKey.m
@@ -186,4 +186,9 @@
     return UINT256_ZERO;
 }
 
+- (void)signMessageDigest:(UInt256)digest completion:(void (^_Nullable)(BOOL success, NSData *signature))completion {
+    NSAssert(NO, @"This should be overridden");
+}
+
+
 @end

--- a/Example/Tests/DSTransitionTests.m
+++ b/Example/Tests/DSTransitionTests.m
@@ -108,6 +108,23 @@
                                  }];
 }
 
+- (void)testIdentitySigning {
+    UInt256 digest = uint256_random;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"signedAndVerifiedMessage"];
+    DSKey *key = [self.blockchainIdentity privateKeyAtIndex:0 ofType:DSKeyType_ECDSA forSeed:self.seedData];
+    [key signMessageDigest:digest
+                completion:^(BOOL success, NSData *_Nonnull signature) {
+                    XCTAssertTrue(success, "The blockchain identity should be able to sign a message digest");
+                    BOOL verified = [self.blockchainIdentity verifySignature:signature forKeyIndex:0 ofType:DSKeyType_ECDSA forMessageDigest:digest];
+                    XCTAssertTrue(verified, "The blockchain identity should be able to verify the message it just signed");
+                    [expectation fulfill];
+                }];
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                     XCTAssertNil(error);
+                                 }];
+}
+
 - (void)testNameRegistration {
     //ToDo
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
We didn't have a method to easily sign message digests for blockchain identities. 


## What was done?
We implemented a method on the blockchain identity to sign a message digest. + some refactoring.


## How Has This Been Tested?
I made a unit test.


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone