### PR TITLE
nil address fix

### DIFF
--- a/DashSync/shared/Models/Wallet/DSAccount.m
+++ b/DashSync/shared/Models/Wallet/DSAccount.m
@@ -1626,7 +1626,7 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
     NSMutableArray<NSString *> *addresses = [NSMutableArray array];
     for (DSTransactionOutput *output in transaction.outputs) {
         NSString *address = output.address;
-        if (address == (id)[NSNull null]) {
+        if (address == nil) {
             if ([self directionOfTransaction:transaction] == DSTransactionDirection_Sent) {
                 NSData *script = output.outScript;
                 if ([script UInt8AtOffset:0] == OP_RETURN) {

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -441,7 +441,7 @@ PODS:
   - gRPC/Interface-Legacy (1.40.0):
     - gRPC-RxLibrary/Interface (= 1.40.0)
   - KVO-MVVM (0.5.1)
-  - Protobuf (3.17.0)
+  - Protobuf (3.18.0)
   - SDWebImage (5.9.2):
     - SDWebImage/Core (= 5.9.2)
   - SDWebImage/Core (5.9.2)
@@ -507,7 +507,7 @@ SPEC CHECKSUMS:
   gRPC-ProtoRPC: 3874566e2aad0268c33c103bcfba6cf062a6d267
   gRPC-RxLibrary: 12532beae7ea079792b9c0fbce4514d37d206f85
   KVO-MVVM: 4df3afd1f7ebcb69735458b85db59c4271ada7c6
-  Protobuf: 7327d4444215b5f18e560a97f879ff5503c4581c
+  Protobuf: 1a37ebea1338949e9ac35a3f06e80b3f536eec8d
   SDWebImage: 0b42b8719ab0c5257177d5894306e8a336b21cbb
   secp256k1_dash: bd60e467aa853e145cf680dd0f8b196df20f0a62
   tinycbor: d4d71dddda1f8392fbb4249f63faf8552f327590


### PR DESCRIPTION
Outputs not have nil addresses instead of NSNull null, this was causing a crash on startup if the wallet had transactions with outputs that were not standard addresses.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone