### PR TITLE
Use one context when saving/creating core data entities

### DIFF
--- a/DashSync/shared/Models/Entities/DSDerivationPathEntity+CoreDataClass.h
+++ b/DashSync/shared/Models/Entities/DSDerivationPathEntity+CoreDataClass.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface DSDerivationPathEntity : NSManagedObject
 
 + (DSDerivationPathEntity *_Nonnull)derivationPathEntityMatchingDerivationPath:(DSDerivationPath *)derivationPath inContext:(NSManagedObjectContext *)context;
++ (DSDerivationPathEntity *_Nonnull)derivationPathEntityMatchingDerivationPath:(DSIncomingFundsDerivationPath *)derivationPath associateWithFriendRequest:(DSFriendRequestEntity *)friendRequest inContext:(NSManagedObjectContext *)context;
 + (DSDerivationPathEntity *_Nonnull)derivationPathEntityMatchingDerivationPath:(DSIncomingFundsDerivationPath *)derivationPath associateWithFriendRequest:(DSFriendRequestEntity *)friendRequest;
 + (void)deleteDerivationPathsOnChainEntity:(DSChainEntity *)chainEntity;
 

--- a/DashSync/shared/Models/Identity/DSBlockchainIdentity.m
+++ b/DashSync/shared/Models/Identity/DSBlockchainIdentity.m
@@ -4335,7 +4335,7 @@ typedef NS_ENUM(NSUInteger, DSBlockchainIdentityKeyDictionary)
         if (!success) {
             return;
         }
-        friendRequestEntity.derivationPath = [friendship storeExtendedPublicKeyAssociatedWithFriendRequest:friendRequestEntity];
+        friendRequestEntity.derivationPath = [friendship storeExtendedPublicKeyAssociatedWithFriendRequest:friendRequestEntity inContext:context];
         
         DSAccount *account = [self.wallet accountWithNumber:0];
         if (friendship.destinationBlockchainIdentity.isLocal) { //the destination is also local

--- a/DashSync/shared/Models/Identity/DSPotentialOneWayFriendship.h
+++ b/DashSync/shared/Models/Identity/DSPotentialOneWayFriendship.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (DSFriendRequestEntity *)outgoingFriendRequestForDashpayUserEntity:(DSDashpayUserEntity *)dashpayUserEntity atTimestamp:(NSTimeInterval)timestamp;
 
+- (DSDerivationPathEntity *)storeExtendedPublicKeyAssociatedWithFriendRequest:(DSFriendRequestEntity *)friendRequestEntity inContext:(NSManagedObjectContext *)context;
 - (DSDerivationPathEntity *)storeExtendedPublicKeyAssociatedWithFriendRequest:(DSFriendRequestEntity *)friendRequestEntity;
 
 - (void)createDerivationPathAndSaveExtendedPublicKeyWithCompletion:(void (^)(BOOL success, DSIncomingFundsDerivationPath *incomingFundsDerivationPath))completion;

--- a/DashSync/shared/Models/Identity/DSPotentialOneWayFriendship.m
+++ b/DashSync/shared/Models/Identity/DSPotentialOneWayFriendship.m
@@ -167,14 +167,19 @@
     return contact;
 }
 
-- (DSDerivationPathEntity *)storeExtendedPublicKeyAssociatedWithFriendRequest:(DSFriendRequestEntity *)friendRequestEntity {
+- (DSDerivationPathEntity *)storeExtendedPublicKeyAssociatedWithFriendRequest:(DSFriendRequestEntity *)friendRequestEntity inContext:(NSManagedObjectContext *)context {
     [self.fundsDerivationPathForContact storeExtendedPublicKeyUnderWalletUniqueId:self.account.wallet.uniqueIDString];
     __block DSDerivationPathEntity *fundsDerivationPathEntity = nil;
-
-    [friendRequestEntity.managedObjectContext performBlockAndWait:^{
-        fundsDerivationPathEntity = [DSDerivationPathEntity derivationPathEntityMatchingDerivationPath:self.fundsDerivationPathForContact associateWithFriendRequest:friendRequestEntity];
+    
+    [context performBlockAndWait:^{
+        fundsDerivationPathEntity = [DSDerivationPathEntity derivationPathEntityMatchingDerivationPath:self.fundsDerivationPathForContact associateWithFriendRequest:friendRequestEntity
+            inContext:context];
     }];
     return fundsDerivationPathEntity;
+}
+
+- (DSDerivationPathEntity *)storeExtendedPublicKeyAssociatedWithFriendRequest:(DSFriendRequestEntity *)friendRequestEntity {
+    return [self storeExtendedPublicKeyAssociatedWithFriendRequest:friendRequestEntity inContext:friendRequestEntity.managedObjectContext];
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Fix the issue when we try to send a contact request and we try to save data into core data from different contexts which leads to the crash.


## What was done?
Whenever we send a contact request and we save data into core data, make sure we always use one core data context


## How Has This Been Tested?
Manually, QA, Tests


## Breaking Changes
N/A


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone