### PR TITLE
Encode assetlocktx and islock query items of the invitation link in lowercased hex format

### DIFF
--- a/DashSync/shared/Models/Identity/DSBlockchainInvitation.m
+++ b/DashSync/shared/Models/Identity/DSBlockchainInvitation.m
@@ -393,13 +393,13 @@
             [queryItems addObject:senderAvatarPathQueryItem];
         }
 
-        NSURLQueryItem *fundingTransactionQueryItem = [NSURLQueryItem queryItemWithName:@"assetlocktx" value:fundingTransactionHexString];
+        NSURLQueryItem *fundingTransactionQueryItem = [NSURLQueryItem queryItemWithName:@"assetlocktx" value:fundingTransactionHexString.lowercaseString];
         [queryItems addObject:fundingTransactionQueryItem];
 
         NSURLQueryItem *registrationFundingPrivateKeyQueryItem = [NSURLQueryItem queryItemWithName:@"pk" value:registrationFundingPrivateKeyString];
         [queryItems addObject:registrationFundingPrivateKeyQueryItem];
 
-        NSURLQueryItem *serializedISLockQueryItem = [NSURLQueryItem queryItemWithName:@"islock" value:serializedISLock];
+        NSURLQueryItem *serializedISLockQueryItem = [NSURLQueryItem queryItemWithName:@"islock" value:serializedISLock.lowercaseString];
         [queryItems addObject:serializedISLockQueryItem];
 
         components.queryItems = queryItems;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
When we generate a link on iOS side the assetlocktx and islock query items are in uppercased hex encoding and android expecting in lowercase format.


## What was done?
The assetlocktx and islock query items are being generated in lowercased hex encoding


## How Has This Been Tested?
Manually


## Breaking Changes
N/A


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone