### PR TITLE
Make sure we initiate dapi network service with a random peer

### DIFF
--- a/DashSync/shared/Models/DAPI/DSDAPIClient.m
+++ b/DashSync/shared/Models/DAPI/DSDAPIClient.m
@@ -284,7 +284,7 @@ NSErrorDomain const DSDAPIClientErrorDomain = @"DSDAPIClientErrorDomain";
 #if DAPI_CONNECT_SINGLE_NODE
             NSString *peerHost = DAPI_SINGLE_NODE;
 #else
-            NSString *peerHost = [[self.availablePeers allObjects]  objectAtIndex:arc4random_uniform((uint32_t)[self.availablePeers count])];
+            NSString *peerHost = [[self.availablePeers allObjects] objectAtIndex:arc4random_uniform((uint32_t)[self.availablePeers count])];
 #endif
             HTTPLoaderFactory *loaderFactory = [DSNetworkingCoordinator sharedInstance].loaderFactory;
             DSDAPICoreNetworkService *DAPINetworkService = [[DSDAPICoreNetworkService alloc] initWithDAPINodeIPAddress:peerHost httpLoaderFactory:loaderFactory usingGRPCDispatchQueue:self.coreNetworkingDispatchQueue onChain:self.chain];

--- a/DashSync/shared/Models/DAPI/DSDAPIClient.m
+++ b/DashSync/shared/Models/DAPI/DSDAPIClient.m
@@ -284,7 +284,7 @@ NSErrorDomain const DSDAPIClientErrorDomain = @"DSDAPIClientErrorDomain";
 #if DAPI_CONNECT_SINGLE_NODE
             NSString *peerHost = DAPI_SINGLE_NODE;
 #else
-            NSString *peerHost = self.availablePeers.anyObject;
+            NSString *peerHost = [[self.availablePeers allObjects]  objectAtIndex:arc4random_uniform((uint32_t)[self.availablePeers count])];
 #endif
             HTTPLoaderFactory *loaderFactory = [DSNetworkingCoordinator sharedInstance].loaderFactory;
             DSDAPICoreNetworkService *DAPINetworkService = [[DSDAPICoreNetworkService alloc] initWithDAPINodeIPAddress:peerHost httpLoaderFactory:loaderFactory usingGRPCDispatchQueue:self.coreNetworkingDispatchQueue onChain:self.chain];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Before, we were retrying peer from `NSSet` using `anyObject` property. The property doesn't return objects randomly and we were facing an issue when we were using the same peer every time.

More info about `anyObject` property of `NSSet` object from docs:
```
One of the objects in the set, or nil if the set contains no objects. The object returned is chosen at the set’s convenience—the selection is not guaranteed to be random.
```


## What was done?
Now we get an array out of `NSSet` using `allObjects` property, then we retrieve a peer by generating a random index using `arc4random_uniform` function.


## How Has This Been Tested?
Manually, Tests


## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone