### PR TITLE
Use the legacy way to serialize bls elements

### DIFF
--- a/DashSync/shared/Models/Keys/NSData+Encryption.mm
+++ b/DashSync/shared/Models/Keys/NSData+Encryption.mm
@@ -75,7 +75,7 @@ static NSData *_Nullable AES256EncryptDecrypt(CCOperation operation,
 - (nullable NSData *)encryptWithBLSSecretKey:(DSBLSKey *)secretKey forPublicKey:(DSBLSKey *)peerPubKey usingInitializationVector:(NSData *)ivData {
     bls::G1Element pk = secretKey.blsPrivateKey * peerPubKey.blsPublicKey;
 
-    std::vector<uint8_t> symKey = pk.Serialize();
+    std::vector<uint8_t> symKey = pk.Serialize(true);
     symKey.resize(32);
 
     NSData *resultData = AES256EncryptDecrypt(kCCEncrypt, self, (uint8_t *)symKey.data(), ivData.bytes);
@@ -94,7 +94,7 @@ static NSData *_Nullable AES256EncryptDecrypt(CCOperation operation,
 - (nullable NSData *)encryptWithDHBLSKey:(DSBLSKey *)dhKey usingInitializationVector:(NSData *)initializationVector {
     unsigned char *iv = (unsigned char *)initializationVector.bytes;
 
-    std::vector<uint8_t> symKey = dhKey.blsPublicKey.Serialize();
+    std::vector<uint8_t> symKey = dhKey.blsPublicKey.Serialize(true);
     symKey.resize(32);
 
     NSData *resultData = AES256EncryptDecrypt(kCCEncrypt, self, (uint8_t *)symKey.data(), initializationVector.length ? iv : 0);
@@ -110,7 +110,7 @@ static NSData *_Nullable AES256EncryptDecrypt(CCOperation operation,
     }
 
     bls::G1Element pk = secretKey.blsPrivateKey * peerPubKey.blsPublicKey;
-    std::vector<uint8_t> symKey = pk.Serialize();
+    std::vector<uint8_t> symKey = pk.Serialize(true);
     symKey.resize(32);
 
     unsigned char iv[ivSize];
@@ -134,7 +134,7 @@ static NSData *_Nullable AES256EncryptDecrypt(CCOperation operation,
     }
 
     bls::G1Element pk = key.blsPublicKey;
-    std::vector<uint8_t> symKey = pk.Serialize();
+    std::vector<uint8_t> symKey = pk.Serialize(true);
     symKey.resize(32);
 
     unsigned char iv[ivSize];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Fix `encryptWithSecretKey` method and fix `testBLSEncryptionAndDecryption` test. 

## What was done?
Use the legacy way to serialize bls elements


## How Has This Been Tested?
Tests

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone