### PR TITLE
fix: update Insight API URLs for sweep balance

### DIFF
--- a/DashSync/shared/Models/Managers/Service Managers/DSInsightManager.m
+++ b/DashSync/shared/Models/Managers/Service Managers/DSInsightManager.m
@@ -20,9 +20,9 @@
 #define TX_PATH @"rawtx"
 #define BLOCK_PATH @"block"
 
-#define INSIGHT_URL @"https://insight.dash.org/insight-api-dash"
-#define INSIGHT_FAILOVER_URL @"https://insight.dash.show/api"
-#define TESTNET_INSIGHT_URL @"https://testnet-insight.dashevo.org/insight-api-dash"
+#define INSIGHT_URL @"https://insight.dash.org/insight-api"
+#define INSIGHT_FAILOVER_URL @"https://insight.dash.org/insight-api"
+#define TESTNET_INSIGHT_URL @"https://insight.testnet.networks.dash.org/insight-api"
 
 @implementation DSInsightManager
 


### PR DESCRIPTION
## Summary
- Update `INSIGHT_URL` from `insight.dash.org/insight-api-dash` (404) to `insight.dash.org/insight-api` (200)
- Update `INSIGHT_FAILOVER_URL` from `insight.dash.show/api` (unreachable) to `insight.dash.org/insight-api` (200)
- Update `TESTNET_INSIGHT_URL` from `testnet-insight.dashevo.org/insight-api-dash` (502) to `insight.testnet.networks.dash.org/insight-api` (200)

## Context
Users reported "Couldn't sweep balance - Unexpected response from (null)" when using Import Private Key. All three Insight API endpoints were returning errors (404, connection refused, 502).

## Test plan
- [ ] Import a private key on mainnet and verify sweep balance succeeds
- [ ] Import a private key on testnet and verify sweep balance succeeds
- [ ] Verify UTXO lookups return valid responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated blockchain network endpoints for improved service reliability and connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->