### PR TITLE
feat(payment): support BIP21 op_return and callback URI parameters

### DIFF
--- a/DashSync/shared/Models/Managers/Chain Managers/DSTransactionManager.m
+++ b/DashSync/shared/Models/Managers/Chain Managers/DSTransactionManager.m
@@ -584,8 +584,18 @@
                                     withFee:YES
                                 coinControl:coinControl];
     } else if (amount <= account.balance) {
-        tx = [account transactionForAmounts:@[@(requestedAmount)]
-                            toOutputScripts:@[protoReq.details.outputScripts.firstObject]
+        // Preserve any auxiliary outputs the request carried beyond the primary
+        // recipient (e.g. a BIP21 op_return data output). Without this, anything
+        // past index 0 in outputScripts is silently dropped from the broadcast tx.
+        NSMutableArray<NSNumber *> *amts = [@[@(requestedAmount)] mutableCopy];
+        NSMutableArray<NSData *> *scripts = [@[protoReq.details.outputScripts.firstObject] mutableCopy];
+        for (NSUInteger i = 1; i < protoReq.details.outputScripts.count; i++) {
+            NSNumber *outAmt = (i < protoReq.details.outputAmounts.count) ? protoReq.details.outputAmounts[i] : @(0);
+            [amts addObject:outAmt];
+            [scripts addObject:protoReq.details.outputScripts[i]];
+        }
+        tx = [account transactionForAmounts:amts
+                            toOutputScripts:scripts
                                     withFee:YES
                                 coinControl:coinControl];
     }

--- a/DashSync/shared/Models/Payment/DSPaymentRequest.h
+++ b/DashSync/shared/Models/Payment/DSPaymentRequest.h
@@ -44,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSString *r; // BIP72 URI: https://github.com/bitcoin/bips/blob/master/bip-0072.mediawiki
 @property (nonatomic, strong, nullable) NSString *string;
 @property (nonatomic, strong, nullable) NSString *callbackScheme;
+@property (nonatomic, strong, nullable) NSData *opReturnData; // raw payload for an OP_RETURN output (BIP21 `op_return=<hex>`), max 80 bytes
+@property (nonatomic, strong, nullable) NSURL *callback; // https URL to open after successful payment (BIP21 `callback=<url>`)
 @property (nonatomic, strong, nullable) NSData *data;
 @property (nonatomic, strong, nullable) NSURL *url;
 @property (nonatomic, strong, nullable) NSString *requestedFiatCurrencyCode;

--- a/DashSync/shared/Models/Payment/DSPaymentRequest.m
+++ b/DashSync/shared/Models/Payment/DSPaymentRequest.m
@@ -39,6 +39,7 @@
 #import "DSKeyManager.h"
 #import "DSPaymentProtocol.h"
 #import "DSPriceManager.h"
+#import "NSData+Dash.h"
 #import "NSError+Dash.h"
 #import "NSMutableData+Dash.h"
 #import "NSString+Bitcoin.h"
@@ -87,6 +88,8 @@
     self.message = nil;
     self.amount = 0;
     self.callbackScheme = nil;
+    self.opReturnData = nil;
+    self.callback = nil;
     self.r = nil;
 
     if (string.length == 0) return;
@@ -162,6 +165,34 @@
                 self.requestedFiatCurrencyAmount = [value floatValue];
             } else if ([key isEqual:@"user"]) {
                 self.dashpayUsername = value;
+            } else if ([key isEqual:@"op_return"]) {
+                // 80-byte cap = Dash standard relay policy. Invalid payloads are silently
+                // dropped per BIP21 unknown-param convention; use req-op_return= to make
+                // an invalid value invalidate the whole request.
+                static NSCharacterSet *nonHex = nil;
+                static dispatch_once_t once = 0;
+                dispatch_once(&once, ^{
+                    nonHex = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789abcdefABCDEF"] invertedSet];
+                });
+                if (value.length > 0 && (value.length % 2 == 0) &&
+                    [value rangeOfCharacterFromSet:nonHex].location == NSNotFound) {
+                    NSData *decoded = [value hexToData];
+                    if (decoded.length > 0 && decoded.length <= 80) {
+                        self.opReturnData = decoded;
+                    } else {
+                        DSLog(@"DSPaymentRequest: dropping op_return param: payload size %lu out of range (1..80)", (unsigned long)decoded.length);
+                    }
+                } else {
+                    DSLog(@"DSPaymentRequest: dropping op_return param: not valid hex");
+                }
+            } else if ([key isEqual:@"callback"]) {
+                // https only: arbitrary schemes would let a URI invoke other app handlers.
+                NSURL *cb = [NSURL URLWithString:value];
+                if (cb && [cb.scheme.lowercaseString isEqualToString:@"https"]) {
+                    self.callback = cb;
+                } else {
+                    DSLog(@"DSPaymentRequest: dropping callback param: not a valid https URL");
+                }
             }
         }
     } else if (url)
@@ -209,6 +240,14 @@
 
     if (self.dashpayUsername.length > 0) {
         [q addObject:[@"user=" stringByAppendingString:self.dashpayUsername]];
+    }
+
+    if (self.opReturnData.length > 0) {
+        [q addObject:[@"op_return=" stringByAppendingString:self.opReturnData.hexString]];
+    }
+
+    if (self.callback) {
+        [q addObject:[@"callback=" stringByAppendingString:[self.callback.absoluteString stringByAddingPercentEncodingWithAllowedCharacters:charset]]];
     }
 
     if (q.count > 0) {
@@ -343,9 +382,17 @@
         }
     }
 
+    NSArray<NSNumber *> *outputAmounts = @[@(sendingAmount)];
+    NSArray<NSData *> *outputScripts = @[script];
+    NSData *opReturnScript = [self opReturnOutputScript];
+    if (opReturnScript) {
+        outputAmounts = [outputAmounts arrayByAddingObject:@(0)];
+        outputScripts = [outputScripts arrayByAddingObject:opReturnScript];
+    }
+
     DSPaymentProtocolDetails *details =
-        [[DSPaymentProtocolDetails alloc] initWithOutputAmounts:@[@(sendingAmount)]
-                                                  outputScripts:@[script]
+        [[DSPaymentProtocolDetails alloc] initWithOutputAmounts:outputAmounts
+                                                  outputScripts:outputScripts
                                                            time:0
                                                         expires:0
                                                            memo:self.message
@@ -361,6 +408,14 @@
                                            callbackScheme:self.callbackScheme];
 
     return request;
+}
+
+- (nullable NSData *)opReturnOutputScript {
+    if (self.opReturnData.length == 0) return nil;
+    NSMutableData *script = [NSMutableData data];
+    [script appendUInt8:OP_RETURN];
+    [script appendScriptPushData:self.opReturnData];
+    return script;
 }
 
 // receiver converted to BIP70 request object
@@ -389,9 +444,17 @@
         }
     }
 
+    NSArray<NSNumber *> *outputAmounts = @[@(sendingAmount)];
+    NSArray<NSData *> *outputScripts = @[script];
+    NSData *opReturnScript = [self opReturnOutputScript];
+    if (opReturnScript) {
+        outputAmounts = [outputAmounts arrayByAddingObject:@(0)];
+        outputScripts = [outputScripts arrayByAddingObject:opReturnScript];
+    }
+
     DSPaymentProtocolDetails *details =
-        [[DSPaymentProtocolDetails alloc] initWithOutputAmounts:@[@(sendingAmount)]
-                                                  outputScripts:@[script]
+        [[DSPaymentProtocolDetails alloc] initWithOutputAmounts:outputAmounts
+                                                  outputScripts:outputScripts
                                                            time:0
                                                         expires:0
                                                            memo:self.message

--- a/DashSync/shared/Models/Wallet/DSAccount.m
+++ b/DashSync/shared/Models/Wallet/DSAccount.m
@@ -720,6 +720,9 @@
                 }
 
                 for (DSTransactionOutput *output in tx.outputs) { // check that no outputs are dust
+                    // OP_RETURN outputs are 0-value by design (provably-unspendable data) and must
+                    // not be flagged as dust, otherwise any tx carrying one stays pending forever.
+                    if (output.outScript.length > 0 && [output.outScript UInt8AtOffset:0] == OP_RETURN) continue;
                     if (output.amount < TX_MIN_OUTPUT_AMOUNT) {
                         pending = YES;
                         DSLogInfo(@"DSAccount", @"received dust output %llu for transaction %@", output.amount, uint256_reverse_hex(tx.txHash));
@@ -1554,6 +1557,8 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
             lockTime > [NSDate timeIntervalSince1970]) return YES;
     }
     for (DSTransactionOutput *output in transaction.outputs) { // check that no outputs are dust
+        // OP_RETURN outputs are 0-value by design and must be exempt from the dust check.
+        if (output.outScript.length > 0 && [output.outScript UInt8AtOffset:0] == OP_RETURN) continue;
         if (output.amount < TX_MIN_OUTPUT_AMOUNT) return YES;
     }
     for (DSTransactionInput *input in transaction.inputs) { // check if any inputs are known to be pending


### PR DESCRIPTION
## Issue being fixed or feature implemented

Adds two new BIP21 URI parameters to `DSPaymentRequest` that
merchant/cross-chain integrations (e.g. THORChain, MAYA, hosted
checkout flows) require:

- **`op_return=<hex>`** — payload (1..80 bytes of hex) attached to
  the broadcast transaction as a 0-value `OP_RETURN` output, used
  for invoice IDs, swap memos, and other payee-side correlation
  data.
- **`callback=<https-url>`** — `https` URL surfaced to the host
  wallet after a successful send so the merchant can complete its
  checkout flow.

The parameters are optional and additive — URIs that do not include
either continue to behave exactly as before.

Example URI:

    dash:DASHVaultInboundAddress?amount=5.0
        &op_return=3d3a544f522e52554e453a74686f72316162633a3132333435
        &callback=https%3A%2F%2Fthordex.app%2F%23%2Fcb%3Fdashpay_cb%3Dab8d4f12e9c7

## What was done?

**`DSPaymentRequest.h` / `.m`**
- New properties: `opReturnData` (`NSData`) and `callback` (`NSURL`).
- `setString:` now parses and validates both parameters:
  - `op_return`: must be even-length hex, decoded payload must be
    1..80 bytes (Dash standard relay limit). Invalid values are
    silently dropped per BIP21 unknown-parameter convention; use
    `req-op_return=` to make an invalid value invalidate the whole
    request.
  - `callback`: must parse as `NSURL` with `https` scheme. Any
    other scheme is rejected at parse time to prevent the URI from
    invoking arbitrary app handlers.
- `string` (the URI round-trip getter) emits the new params when
  set.
- New `opReturnOutputScript` helper builds the canonical
  `OP_RETURN <pushdata>` script.
- Both `protocolRequest` and
  `protocolRequestForBlockchainIdentity:` append the OP_RETURN
  output (at amount 0) onto `DSPaymentProtocolDetails.outputAmounts`
  / `outputScripts` when present.

**`DSTransactionManager.m`**
- In `confirmProtocolRequest:forAmount:…`, the
  `requestedAmount != 0` branch previously forwarded only
  `outputScripts.firstObject`, which silently dropped any auxiliary
  outputs the protocol request carried. It now appends every
  output at indices 1..N alongside the primary recipient so the
  OP_RETURN reaches the signed and broadcast transaction. No-op
  for URIs without `op_return`.

**`DSAccount.m`**
- Two dust-check loops (`transactionIsPending:` and the balance /
  UTXO update path) now exempt outputs whose script begins with
  `OP_RETURN` (`0x6a`). Without this exemption the spec-mandated
  0-value null-data output marks the entire transaction as
  forever-pending and prevents its balance from settling locally.
  Uses the same `[script UInt8AtOffset:0] == OP_RETURN` idiom
  already used elsewhere in the file.

## How Has This Been Tested?

Manual end-to-end testing on Dash mainnet via the dashwallet-ios
host app (iOS 26.5, Xcode 16), against `Dash Core:23.1.2` peers:

- Scanned a BIP21 URI of the form
  `dash:<addr>?amount=0.001&op_return=74657374&callback=https%3A%2F%2Fgoogle.com`
  → transaction broadcasts, confirms on chain, and inspecting it
  on insight.dash.org / blockchair shows the expected 3-output
  shape: P2PKH recipient (100 000 duffs) + 0-value `OP_RETURN
  6a 04 74657374` + change. The callback opens cleanly in
  `SFSafariViewController` after the send.
- Repeated against a different recipient address — second
  on-chain confirmation reproduces the result independently.
- Control: URI without `op_return` continues to produce a normal
  2-output transaction (recipient + change), also confirmed on
  chain.
- Negative parsing cases:
  - Non-hex / odd-length / over-80-byte `op_return` values are
    dropped with a `DSLog` line and the request remains spendable.
  - Non-`https` `callback` schemes are rejected at parse time.
- Regression for the dust-check fix: transactions carrying an
  OP_RETURN no longer get stuck flagged as pending in the
  receiving wallet, and on-chain balance updates settle as
  expected.

No automated unit-test coverage was added in this PR; if the
maintainers want a `DSPaymentRequestTests` case for the new parser
branches added before merge, happy to push a follow-up.

## Breaking Changes

None. Both new URI parameters are optional and parsing of any
existing URI is unchanged. No public-API signatures were modified;
new properties are additive.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for BIP21 `op_return` parameter to include auxiliary data in payment requests (limited to 80 bytes).
  * Added HTTPS-only `callback` parameter validation for payment requests.

* **Bug Fixes**
  * Fixed transaction construction to preserve auxiliary outputs beyond primary recipient data.
  * Fixed incorrect pending status assignment for transactions with auxiliary data outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/dashsync-iOS/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->